### PR TITLE
fix infinite loop crash - issue #495

### DIFF
--- a/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Swizzling.swift
+++ b/SkeletonViewCore/Sources/Internal/UIKitExtensions/UIView+Swizzling.swift
@@ -17,7 +17,6 @@ extension UIView {
 
     @objc func skeletonLayoutSubviews() {
         guard Thread.isMainThread else { return }
-        skeletonLayoutSubviews()
         guard sk.isSkeletonActive else { return }
         layoutSkeletonIfNeeded()
     }


### PR DESCRIPTION
Fix an infinite loop caused by calling skeletonLayoutSubviews within itself. This sometimes can cause an infinite loop and a crash.

### Summary

Describe the goal of this PR. Mention any related Issue numbers.

### Requirements (place an `x` in each of the `[ ]`)
* [ ] I've read and understood the [Contributing guidelines](https://github.com/Juanpe/SkeletonView/blob/main/CONTRIBUTING.md) and have done my best effort to follow them.
* [ ] I've read and agree to the [Code of Conduct](https://github.com/Juanpe/SkeletonView/blob/main/CODE_OF_CONDUCT.md).
